### PR TITLE
Week 1 : [wip] Remove realize from __setitem__ and get TestSetitemLoop.test_arange to be one kernel

### DIFF
--- a/draft-pr.md
+++ b/draft-pr.md
@@ -1,0 +1,62 @@
+# [Bounty] Remove realize from __setitem__ and get TestSetitemLoop.test_arange to be one kernel
+
+## Overview
+
+This PR optimizes setitem operations by removing the `realize()` call from the `__setitem__` method in the Tensor class. 
+
+- [x] integer indexing
+- [x] slice indexing
+- [x] ellipsis indexing
+- [x] None indexing
+- [ ] Tensor indexing (not supported yet, but properly handled by existing code `_getitem`)
+
+Pseudo code for the new `__setitem__` implementation is as follows:
+
+```python
+def __setitem__(self, indices, v):
+  mask = self._generate_setitem_mask(indices)
+  padded_v - self._generate_setitem_padded_value(indices, v)
+  res = mask.where(padded_v, self)
+  self.assign(res)
+```
+
+## Performance Improvement
+
+**TestSetitemLoop.test_arange benchmark** with `RANGEIFY=1`:
+- **Master branch**: 20 kernels scheduled in total
+- **This PR**: 3 kernels  
+- **Command**: `DEBUG=1 RANGEIFY=1 python -m pytest test/test_setitem.py::TestSetitemLoop -rP`
+- **Improvement**: 85% reduction in kernel count
+
+This optimization significantly benefits scenarios with repeated setitem operations, such as tensor initialization loops and in-place tensor modifications.
+
+## ❌ Failing Test Case
+
+**Test**: `test_setitem.py::TestSetitem::test_setitem_inplace_mul`  
+**Error**: `AssertionError: must be BUFFER Ops.BUFFER_VIEW`
+
+**Root cause**: The `assign` method cannot properly handle tensor views (even contiguous slices) during buffer realization. When inplace operations like `*=` call `assign` on slice views, the underlying buffer system fails because it encounters a `BUFFER_VIEW` operation instead of the expected `BUFFER` operation.
+
+**Technical details**:
+```
+t[:3] = t[:3] * 10 # This works fine
+t[:3] *= 10        # But this causes a crash when realized
+```
+- Python interpreter internally translates the expression like this `t[:3] *= 10` into the code below:
+```python
+_slice = t[:3]
+_slice += 10
+t[:3] = _slice
+```
+- During realization, the buffer property assertion fails: `assert self.op is Ops.BUFFER`  
+- The system encounters `Ops.BUFFER_VIEW` instead of `Ops.BUFFER`, causing the crash
+
+**Conflict**: This test can be fixed by changing `__imul__` to use `replace` instead of `assign`, but then `test_assign.py::TestAssign::test_permuted_assignment` would fail because it expects inplace operations to properly reject non-contiguous tensors.
+
+## Possible Solutions
+
+I'm considering these approaches, but unsure which is best. Are there better alternatives?
+
+1. **Fix assign for views**: Modify `assign` method to detect slice views and handle them appropriately  
+2. **Fix buffer realization**: Update the `realize()` pipeline to properly handle `BUFFER_VIEW` operations
+

--- a/setitem.py
+++ b/setitem.py
@@ -1,7 +1,7 @@
 from tinygrad import Tensor
 import functools
 
-def gen_mask(self: Tensor, indices):
+def gen_mask(self, indices):
     masks = []
     for dim,(dim_size, idx) in enumerate(zip(self.shape, indices)):
         if isinstance(idx, int):
@@ -11,6 +11,7 @@ def gen_mask(self: Tensor, indices):
         elif isinstance(idx, slice):
             # e.g. dim=3, idx=slice(1,12,3) = [1,4,7,10], shape=(10,20,30,40,50)
             #              () -> (4,) -> (4,20) -> (20,) -> (1,20,1,1,1) -> (10,20,30,40,50)
+            # TODO: Negative start/stop/step, but mask should be correct
             # Negative start/stop is handled by slice.indices, but negative step could be tricky
             start, stop, step = idx.indices(dim_size)
             mask = Tensor.arange(start, stop, step).one_hot(dim_size).sum(0).reshape((1,)*dim + (dim_size,) + (1,)*(self.ndim-dim-1)).expand(self.shape)
@@ -27,48 +28,52 @@ x : (10,20,30,40,50)
 v : (10, 1, 30, 4, 50) or broadcastable to this shape
 x[:, 3, ..., 1:12:3] = v
 """
-def gen_index_shape(shape: tuple[int,...], indices):
+def gen_index_shape(self, indices):
     masks = []
-    ndim = len(shape)
-    indices = list(indices) + [None]*(ndim - len(indices))
+    indices = list(indices) + [None]*(self.ndim - len(indices))
     res_shape = []
-    for (dim_size, idx) in zip(shape, indices):
+    for (dim_size, idx) in zip(self.shape, indices):
         if isinstance(idx, int):
             res_shape.append(1)
         elif isinstance(idx, slice):
-            start = idx.start or 0
-            stop = idx.stop or dim_size
-            step = idx.step or 1
-            res_shape.append((stop - start + (step or 1) - 1) // (step or 1))
+            start, stop, step = idx.indices(dim_size)
+            size = (abs(stop - start) + abs(step) - 1) // abs(step)
+            print(f"{start=}, {stop=}, {step=}, {size=}")
+            res_shape.append(size)
         elif idx is None:
             res_shape.append(dim_size)
         else:
             raise NotImplementedError(f"Indexing with {type(idx)} not supported")
     return tuple(res_shape)
 
-def pad_values(v: Tensor, shape: tuple[int,...], indices):
-    vshape = gen_index_shape(shape, indices)
+def pad_values(self, v: Tensor, indices):
+    vshape = gen_index_shape(self, indices)
     print(f"{vshape=}")
-    ndim = len(shape)
     # e.g.
     # v.shape = (1, 1, 4, 1) -> (10, 1, 30, 4, 50)
     vb = v._broadcast_to(vshape)
     padding = []
-    for dim,(dim_size, idx) in enumerate(zip(shape, indices)):
+    for dim,(dim_size, idx) in enumerate(zip(self.shape, indices)):
         print(f"dim={dim}, idx={idx}, dim_size={dim_size}")
         if isinstance(idx, int):
             pass
         elif isinstance(idx, slice):
-            start = idx.start or 0
-            stop = idx.stop or dim_size
-            step = idx.step or 1
-            if step > 1:
+            start, stop, step = idx.indices(dim_size)
+            if step < 0:
+                vb = vb.flip(dim)
+            if abs(step) > 1:
                 # (10,1,30,4,50) -> (10,1,30,12,50) -> (10,1,30,(1+12+17),50)
-                vb = vb.repeat_interleave(step, dim=dim)
+                vb = vb.repeat_interleave(abs(step), dim=dim)
                 # e.g. dim=3, idx=slice(1,12,3) = [1,4,7,10], shape=(10,20,30,40,50)
             # pads = (None, None, (1, 17), 0, None)
-            pad = (start, dim_size - (start + vshape[dim]*step ))
-            pads = (None,) * dim + (pad, ) + (None,) * (ndim - dim - 1)
+            if step > 0:
+                pad = (start, dim_size - (start + vshape[dim]*step ))
+            else:
+                print(f"{dim_size=}, {stop=}, {vshape[dim]=}, {step=}")
+                right_pad = dim_size - start - 1
+                left_pad = dim_size - vb.shape[dim] - right_pad
+                pad = (left_pad, right_pad)
+            pads = (None,) * dim + (pad, ) + (None,) * (self.ndim - dim - 1)
             print(f"{pads=}")
             vb = vb.pad(pads)
         elif idx is None:
@@ -77,13 +82,13 @@ def pad_values(v: Tensor, shape: tuple[int,...], indices):
             raise NotImplementedError(f"Indexing with {type(idx)} not supported")
     return vb
 
-def setitem(x: Tensor, indices, v: Tensor):
-    shape = x.shape
-    mask = gen_mask(x, indices)
-    vb = pad_values(v, shape, indices)
+def setitem(self: Tensor, indices, v: Tensor):
+    print(f"setitem: {self.shape=}, {indices=}, {v.shape=}")
+    mask = gen_mask(self, indices)
     print(f"{mask.numpy()=}")
+    vb = pad_values(self, v, indices)
     print(f"{vb.numpy()=}")
-    return mask.where(vb, x)
+    return mask.where(vb, self)
 
 def test_gen_mask():
     # single element
@@ -114,10 +119,40 @@ def test_gen_mask():
     assert (mask == Tensor([[[0,0,0,0],[0,0,0,0],[0,0,0,0]],[[0,0,0,0],[1,0,1,0],[1,0,1,0]]])).sum().item() == 24
     
 def test_setitem():
-    x = Tensor.zeros(2, 3, 4)
-    v = Tensor.arange(1, 5).reshape((2,2))
+    def initial():
+        x = Tensor.zeros(2,3,4)
+        v = Tensor.arange(1,5).reshape((2,2))
+        return x, v
+    print("========= setitem (Slice Indexing) =========")
+    x, v = initial()
     print(f"{x.numpy()=}")
     print(f"{v.numpy()=}")
+    x = setitem(x, (None, slice(1,3), slice(1,3)), v)
+    print(f"{x.numpy()=}")
+
+    print("========= setitem (Slice Indexing - Strided) =========")
+    x, v = initial()
     x = setitem(x, (None, slice(1,3), slice(1,4,2)), v)
+    print(f"{x.numpy()=}")
+
+    print("========= setitem (Slice Indexing - Negative Step) =========")
+    x, v = initial()
+    x = setitem(x, (None, slice(1,3), slice(3,1,-1)), v)
+    print(f"{x.numpy()=}")
+
+    print("========= setitem (Slice Indexing - Negative Step 2) =========")
+    x, v = initial()
+    x = setitem(x, (None, slice(1,None,-1), slice(3,1,-1)), v)
+    print(f"{x.numpy()=}")
+
+    print("========= setitem (Slice Indexing - Negative Strided) =========")
+    x, v = initial()
+    x = setitem(x, (None, slice(1,3), slice(3,0,-2)), v)
+    print(f"{x.numpy()=}")
+
+    print("========= setitem (Slice Indexing - Negative Stop) =========")
+    x = Tensor([[3.0], [2.0], [1.0]]).contiguous()
+    #x[:-1] = t[1:]
+    x = setitem(x, (slice(None, -1), ), x[1:])
     print(f"{x.numpy()=}")
 

--- a/setitem.py
+++ b/setitem.py
@@ -1,0 +1,123 @@
+from tinygrad import Tensor
+import functools
+
+def gen_mask(self: Tensor, indices):
+    masks = []
+    for dim,(dim_size, idx) in enumerate(zip(self.shape, indices)):
+        if isinstance(idx, int):
+            # e.g. dim=1, idx=3, shape=(10,20,30,40,50)
+            #              () -> (20,) -> (1,20,1,1,1) -> (10,20,30,40,50)
+            mask = Tensor(idx).one_hot(dim_size).reshape((1,)*dim + (dim_size,) + (1,)*(self.ndim-dim-1)).expand(self.shape)
+        elif isinstance(idx, slice):
+            # e.g. dim=3, idx=slice(1,12,3) = [1,4,7,10], shape=(10,20,30,40,50)
+            #              () -> (4,) -> (4,20) -> (20,) -> (1,20,1,1,1) -> (10,20,30,40,50)
+            # Negative start/stop is handled by slice.indices, but negative step could be tricky
+            start, stop, step = idx.indices(dim_size)
+            mask = Tensor.arange(start, stop, step).one_hot(dim_size).sum(0).reshape((1,)*dim + (dim_size,) + (1,)*(self.ndim-dim-1)).expand(self.shape)
+        elif idx is None:
+            continue
+        else:
+            raise NotImplementedError(f"Indexing with {type(idx)} not supported")
+        masks.append(mask)
+    return functools.reduce(lambda x,y: x.mul(y), masks)
+
+"""
+e.g.
+x : (10,20,30,40,50)
+v : (10, 1, 30, 4, 50) or broadcastable to this shape
+x[:, 3, ..., 1:12:3] = v
+"""
+def gen_index_shape(shape: tuple[int,...], indices):
+    masks = []
+    ndim = len(shape)
+    indices = list(indices) + [None]*(ndim - len(indices))
+    res_shape = []
+    for (dim_size, idx) in zip(shape, indices):
+        if isinstance(idx, int):
+            res_shape.append(1)
+        elif isinstance(idx, slice):
+            start = idx.start or 0
+            stop = idx.stop or dim_size
+            step = idx.step or 1
+            res_shape.append((stop - start + (step or 1) - 1) // (step or 1))
+        elif idx is None:
+            res_shape.append(dim_size)
+        else:
+            raise NotImplementedError(f"Indexing with {type(idx)} not supported")
+    return tuple(res_shape)
+
+def pad_values(v: Tensor, shape: tuple[int,...], indices):
+    vshape = gen_index_shape(shape, indices)
+    print(f"{vshape=}")
+    ndim = len(shape)
+    # e.g.
+    # v.shape = (1, 1, 4, 1) -> (10, 1, 30, 4, 50)
+    vb = v._broadcast_to(vshape)
+    padding = []
+    for dim,(dim_size, idx) in enumerate(zip(shape, indices)):
+        print(f"dim={dim}, idx={idx}, dim_size={dim_size}")
+        if isinstance(idx, int):
+            pass
+        elif isinstance(idx, slice):
+            start = idx.start or 0
+            stop = idx.stop or dim_size
+            step = idx.step or 1
+            if step > 1:
+                # (10,1,30,4,50) -> (10,1,30,12,50) -> (10,1,30,(1+12+17),50)
+                vb = vb.repeat_interleave(step, dim=dim)
+                # e.g. dim=3, idx=slice(1,12,3) = [1,4,7,10], shape=(10,20,30,40,50)
+            # pads = (None, None, (1, 17), 0, None)
+            pad = (start, dim_size - (start + vshape[dim]*step ))
+            pads = (None,) * dim + (pad, ) + (None,) * (ndim - dim - 1)
+            print(f"{pads=}")
+            vb = vb.pad(pads)
+        elif idx is None:
+            pass
+        else:
+            raise NotImplementedError(f"Indexing with {type(idx)} not supported")
+    return vb
+
+def setitem(x: Tensor, indices, v: Tensor):
+    shape = x.shape
+    mask = gen_mask(x, indices)
+    vb = pad_values(v, shape, indices)
+    print(f"{mask.numpy()=}")
+    print(f"{vb.numpy()=}")
+    return mask.where(vb, x)
+
+def test_gen_mask():
+    # single element
+    x = Tensor.arange(6).reshape(2,3)
+    mask = gen_mask(x, (1,2))
+    print(f"{mask.numpy()=}")
+    assert (mask == Tensor([[0,0,0],[0,0,1]])).sum().item() == 6
+
+    # single element 2
+    mask = gen_mask(x, (0,1))
+    print(f"{mask.numpy()=}")
+    assert (mask == Tensor([[0,1,0],[0,0,0]])).sum().item() == 6
+
+    # partial indexing
+    mask = gen_mask(x, (0,))
+    print(f"{mask.numpy()=}")
+    assert (mask == Tensor([[1,1,1],[0,0,0]])).sum().item() == 6
+
+    # partial indexing
+    mask = gen_mask(x, (None,1))
+    print(f"{mask.numpy()=}")
+    assert (mask == Tensor([[0,1,0],[0,1,0]])).sum().item() == 6
+
+    # slice indexing
+    x = Tensor.arange(24).reshape(2,3,4)
+    mask = gen_mask(x, (1, slice(1,3), slice(0,4,2)))
+    print(f"{mask.numpy()=}")
+    assert (mask == Tensor([[[0,0,0,0],[0,0,0,0],[0,0,0,0]],[[0,0,0,0],[1,0,1,0],[1,0,1,0]]])).sum().item() == 24
+    
+def test_setitem():
+    x = Tensor.zeros(2, 3, 4)
+    v = Tensor.arange(1, 5).reshape((2,2))
+    print(f"{x.numpy()=}")
+    print(f"{v.numpy()=}")
+    x = setitem(x, (None, slice(1,3), slice(1,4,2)), v)
+    print(f"{x.numpy()=}")
+

--- a/setitem.py
+++ b/setitem.py
@@ -2,25 +2,25 @@ from tinygrad import Tensor
 import functools
 
 def gen_mask(self, indices):
-    masks = []
-    for dim,(dim_size, idx) in enumerate(zip(self.shape, indices)):
-        if isinstance(idx, int):
-            # e.g. dim=1, idx=3, shape=(10,20,30,40,50)
-            #              () -> (20,) -> (1,20,1,1,1) -> (10,20,30,40,50)
-            mask = Tensor(idx).one_hot(dim_size).reshape((1,)*dim + (dim_size,) + (1,)*(self.ndim-dim-1)).expand(self.shape)
-        elif isinstance(idx, slice):
-            # e.g. dim=3, idx=slice(1,12,3) = [1,4,7,10], shape=(10,20,30,40,50)
-            #              () -> (4,) -> (4,20) -> (20,) -> (1,20,1,1,1) -> (10,20,30,40,50)
-            # TODO: Negative start/stop/step, but mask should be correct
-            # Negative start/stop is handled by slice.indices, but negative step could be tricky
-            start, stop, step = idx.indices(dim_size)
-            mask = Tensor.arange(start, stop, step).one_hot(dim_size).sum(0).reshape((1,)*dim + (dim_size,) + (1,)*(self.ndim-dim-1)).expand(self.shape)
-        elif idx is None:
-            continue
-        else:
-            raise NotImplementedError(f"Indexing with {type(idx)} not supported")
-        masks.append(mask)
-    return functools.reduce(lambda x,y: x.mul(y), masks)
+  masks = []
+  for dim,(dim_size, idx) in enumerate(zip(self.shape, indices)):
+    if isinstance(idx, int):
+      # e.g. dim=1, idx=3, shape=(10,20,30,40,50)
+      #              () -> (20,) -> (1,20,1,1,1) -> (10,20,30,40,50)
+      mask = Tensor(idx).one_hot(dim_size).reshape((1,)*dim + (dim_size,) + (1,)*(self.ndim-dim-1)).expand(self.shape)
+    elif isinstance(idx, slice):
+      # e.g. dim=3, idx=slice(1,12,3) = [1,4,7,10], shape=(10,20,30,40,50)
+      #              () -> (4,) -> (4,20) -> (20,) -> (1,20,1,1,1) -> (10,20,30,40,50)
+      # TODO: Negative start/stop/step, but mask should be correct
+      # Negative start/stop is handled by slice.indices, but negative step could be tricky
+      start, stop, step = idx.indices(dim_size)
+      mask = Tensor.arange(start, stop, step).one_hot(dim_size).sum(0).reshape((1,)*dim + (dim_size,) + (1,)*(self.ndim-dim-1)).expand(self.shape)
+    elif idx is None:
+      continue
+    else:
+      raise NotImplementedError(f"Indexing with {type(idx)} not supported")
+    masks.append(mask)
+  return functools.reduce(lambda x,y: x.mul(y), masks)
 
 """
 e.g.
@@ -29,130 +29,130 @@ v : (10, 1, 30, 4, 50) or broadcastable to this shape
 x[:, 3, ..., 1:12:3] = v
 """
 def gen_index_shape(self, indices):
-    masks = []
-    indices = list(indices) + [None]*(self.ndim - len(indices))
-    res_shape = []
-    for (dim_size, idx) in zip(self.shape, indices):
-        if isinstance(idx, int):
-            res_shape.append(1)
-        elif isinstance(idx, slice):
-            start, stop, step = idx.indices(dim_size)
-            size = (abs(stop - start) + abs(step) - 1) // abs(step)
-            print(f"{start=}, {stop=}, {step=}, {size=}")
-            res_shape.append(size)
-        elif idx is None:
-            res_shape.append(dim_size)
-        else:
-            raise NotImplementedError(f"Indexing with {type(idx)} not supported")
-    return tuple(res_shape)
+  masks = []
+  indices = list(indices) + [None]*(self.ndim - len(indices))
+  res_shape = []
+  for (dim_size, idx) in zip(self.shape, indices):
+    if isinstance(idx, int):
+      res_shape.append(1)
+    elif isinstance(idx, slice):
+      start, stop, step = idx.indices(dim_size)
+      size = (abs(stop - start) + abs(step) - 1) // abs(step)
+      print(f"{start=}, {stop=}, {step=}, {size=}")
+      res_shape.append(size)
+    elif idx is None:
+      res_shape.append(dim_size)
+    else:
+      raise NotImplementedError(f"Indexing with {type(idx)} not supported")
+  return tuple(res_shape)
 
 def pad_values(self, v: Tensor, indices):
-    vshape = gen_index_shape(self, indices)
-    print(f"{vshape=}")
-    # e.g.
-    # v.shape = (1, 1, 4, 1) -> (10, 1, 30, 4, 50)
-    vb = v._broadcast_to(vshape)
-    padding = []
-    for dim,(dim_size, idx) in enumerate(zip(self.shape, indices)):
-        print(f"dim={dim}, idx={idx}, dim_size={dim_size}")
-        if isinstance(idx, int):
-            pass
-        elif isinstance(idx, slice):
-            start, stop, step = idx.indices(dim_size)
-            if step < 0:
-                vb = vb.flip(dim)
-            if abs(step) > 1:
-                # (10,1,30,4,50) -> (10,1,30,12,50) -> (10,1,30,(1+12+17),50)
-                vb = vb.repeat_interleave(abs(step), dim=dim)
-                # e.g. dim=3, idx=slice(1,12,3) = [1,4,7,10], shape=(10,20,30,40,50)
-            # pads = (None, None, (1, 17), 0, None)
-            if step > 0:
-                pad = (start, dim_size - (start + vshape[dim]*step ))
-            else:
-                print(f"{dim_size=}, {stop=}, {vshape[dim]=}, {step=}")
-                right_pad = dim_size - start - 1
-                left_pad = dim_size - vb.shape[dim] - right_pad
-                pad = (left_pad, right_pad)
-            pads = (None,) * dim + (pad, ) + (None,) * (self.ndim - dim - 1)
-            print(f"{pads=}")
-            vb = vb.pad(pads)
-        elif idx is None:
-            pass
-        else:
-            raise NotImplementedError(f"Indexing with {type(idx)} not supported")
-    return vb
+  vshape = gen_index_shape(self, indices)
+  print(f"{vshape=}")
+  # e.g.
+  # v.shape = (1, 1, 4, 1) -> (10, 1, 30, 4, 50)
+  vb = v._broadcast_to(vshape)
+  padding = []
+  for dim,(dim_size, idx) in enumerate(zip(self.shape, indices)):
+    print(f"dim={dim}, idx={idx}, dim_size={dim_size}")
+    if isinstance(idx, int):
+      pass
+    elif isinstance(idx, slice):
+      start, stop, step = idx.indices(dim_size)
+      if step < 0:
+        vb = vb.flip(dim)
+      if abs(step) > 1:
+        # (10,1,30,4,50) -> (10,1,30,12,50) -> (10,1,30,(1+12+17),50)
+        vb = vb.repeat_interleave(abs(step), dim=dim)
+        # e.g. dim=3, idx=slice(1,12,3) = [1,4,7,10], shape=(10,20,30,40,50)
+      # pads = (None, None, (1, 17), 0, None)
+      if step > 0:
+        pad = (start, dim_size - (start + vshape[dim]*step ))
+      else:
+        print(f"{dim_size=}, {stop=}, {vshape[dim]=}, {step=}")
+        right_pad = dim_size - start - 1
+        left_pad = dim_size - vb.shape[dim] - right_pad
+        pad = (left_pad, right_pad)
+      pads = (None,) * dim + (pad, ) + (None,) * (self.ndim - dim - 1)
+      print(f"{pads=}")
+      vb = vb.pad(pads)
+    elif idx is None:
+      pass
+    else:
+      raise NotImplementedError(f"Indexing with {type(idx)} not supported")
+  return vb
 
 def setitem(self: Tensor, indices, v: Tensor):
-    print(f"setitem: {self.shape=}, {indices=}, {v.shape=}")
-    mask = gen_mask(self, indices)
-    print(f"{mask.numpy()=}")
-    vb = pad_values(self, v, indices)
-    print(f"{vb.numpy()=}")
-    return mask.where(vb, self)
+  print(f"setitem: {self.shape=}, {indices=}, {v.shape=}")
+  mask = gen_mask(self, indices)
+  print(f"{mask.numpy()=}")
+  vb = pad_values(self, v, indices)
+  print(f"{vb.numpy()=}")
+  return mask.where(vb, self)
 
 def test_gen_mask():
-    # single element
-    x = Tensor.arange(6).reshape(2,3)
-    mask = gen_mask(x, (1,2))
-    print(f"{mask.numpy()=}")
-    assert (mask == Tensor([[0,0,0],[0,0,1]])).sum().item() == 6
+  # single element
+  x = Tensor.arange(6).reshape(2,3)
+  mask = gen_mask(x, (1,2))
+  print(f"{mask.numpy()=}")
+  assert (mask == Tensor([[0,0,0],[0,0,1]])).sum().item() == 6
 
-    # single element 2
-    mask = gen_mask(x, (0,1))
-    print(f"{mask.numpy()=}")
-    assert (mask == Tensor([[0,1,0],[0,0,0]])).sum().item() == 6
+  # single element 2
+  mask = gen_mask(x, (0,1))
+  print(f"{mask.numpy()=}")
+  assert (mask == Tensor([[0,1,0],[0,0,0]])).sum().item() == 6
 
-    # partial indexing
-    mask = gen_mask(x, (0,))
-    print(f"{mask.numpy()=}")
-    assert (mask == Tensor([[1,1,1],[0,0,0]])).sum().item() == 6
+  # partial indexing
+  mask = gen_mask(x, (0,))
+  print(f"{mask.numpy()=}")
+  assert (mask == Tensor([[1,1,1],[0,0,0]])).sum().item() == 6
 
-    # partial indexing
-    mask = gen_mask(x, (None,1))
-    print(f"{mask.numpy()=}")
-    assert (mask == Tensor([[0,1,0],[0,1,0]])).sum().item() == 6
+  # partial indexing
+  mask = gen_mask(x, (None,1))
+  print(f"{mask.numpy()=}")
+  assert (mask == Tensor([[0,1,0],[0,1,0]])).sum().item() == 6
 
-    # slice indexing
-    x = Tensor.arange(24).reshape(2,3,4)
-    mask = gen_mask(x, (1, slice(1,3), slice(0,4,2)))
-    print(f"{mask.numpy()=}")
-    assert (mask == Tensor([[[0,0,0,0],[0,0,0,0],[0,0,0,0]],[[0,0,0,0],[1,0,1,0],[1,0,1,0]]])).sum().item() == 24
-    
+  # slice indexing
+  x = Tensor.arange(24).reshape(2,3,4)
+  mask = gen_mask(x, (1, slice(1,3), slice(0,4,2)))
+  print(f"{mask.numpy()=}")
+  assert (mask == Tensor([[[0,0,0,0],[0,0,0,0],[0,0,0,0]],[[0,0,0,0],[1,0,1,0],[1,0,1,0]]])).sum().item() == 24
+
 def test_setitem():
-    def initial():
-        x = Tensor.zeros(2,3,4)
-        v = Tensor.arange(1,5).reshape((2,2))
-        return x, v
-    print("========= setitem (Slice Indexing) =========")
-    x, v = initial()
-    print(f"{x.numpy()=}")
-    print(f"{v.numpy()=}")
-    x = setitem(x, (None, slice(1,3), slice(1,3)), v)
-    print(f"{x.numpy()=}")
+  def initial():
+    x = Tensor.zeros(2,3,4)
+    v = Tensor.arange(1,5).reshape((2,2))
+    return x, v
+  print("========= setitem (Slice Indexing) =========")
+  x, v = initial()
+  print(f"{x.numpy()=}")
+  print(f"{v.numpy()=}")
+  x = setitem(x, (None, slice(1,3), slice(1,3)), v)
+  print(f"{x.numpy()=}")
 
-    print("========= setitem (Slice Indexing - Strided) =========")
-    x, v = initial()
-    x = setitem(x, (None, slice(1,3), slice(1,4,2)), v)
-    print(f"{x.numpy()=}")
+  print("========= setitem (Slice Indexing - Strided) =========")
+  x, v = initial()
+  x = setitem(x, (None, slice(1,3), slice(1,4,2)), v)
+  print(f"{x.numpy()=}")
 
-    print("========= setitem (Slice Indexing - Negative Step) =========")
-    x, v = initial()
-    x = setitem(x, (None, slice(1,3), slice(3,1,-1)), v)
-    print(f"{x.numpy()=}")
+  print("========= setitem (Slice Indexing - Negative Step) =========")
+  x, v = initial()
+  x = setitem(x, (None, slice(1,3), slice(3,1,-1)), v)
+  print(f"{x.numpy()=}")
 
-    print("========= setitem (Slice Indexing - Negative Step 2) =========")
-    x, v = initial()
-    x = setitem(x, (None, slice(1,None,-1), slice(3,1,-1)), v)
-    print(f"{x.numpy()=}")
+  print("========= setitem (Slice Indexing - Negative Step 2) =========")
+  x, v = initial()
+  x = setitem(x, (None, slice(1,None,-1), slice(3,1,-1)), v)
+  print(f"{x.numpy()=}")
 
-    print("========= setitem (Slice Indexing - Negative Strided) =========")
-    x, v = initial()
-    x = setitem(x, (None, slice(1,3), slice(3,0,-2)), v)
-    print(f"{x.numpy()=}")
+  print("========= setitem (Slice Indexing - Negative Strided) =========")
+  x, v = initial()
+  x = setitem(x, (None, slice(1,3), slice(3,0,-2)), v)
+  print(f"{x.numpy()=}")
 
-    print("========= setitem (Slice Indexing - Negative Stop) =========")
-    x = Tensor([[3.0], [2.0], [1.0]]).contiguous()
-    #x[:-1] = t[1:]
-    x = setitem(x, (slice(None, -1), ), x[1:])
-    print(f"{x.numpy()=}")
+  print("========= setitem (Slice Indexing - Negative Stop) =========")
+  x = Tensor([[3.0], [2.0], [1.0]]).contiguous()
+  #x[:-1] = t[1:]
+  x = setitem(x, (slice(None, -1), ), x[1:])
+  print(f"{x.numpy()=}")
 

--- a/setitem.py
+++ b/setitem.py
@@ -29,7 +29,6 @@ v : (10, 1, 30, 4, 50) or broadcastable to this shape
 x[:, 3, ..., 1:12:3] = v
 """
 def gen_index_shape(self, indices):
-  masks = []
   indices = list(indices) + [None]*(self.ndim - len(indices))
   res_shape = []
   for (dim_size, idx) in zip(self.shape, indices):
@@ -52,7 +51,6 @@ def pad_values(self, v: Tensor, indices):
   # e.g.
   # v.shape = (1, 1, 4, 1) -> (10, 1, 30, 4, 50)
   vb = v._broadcast_to(vshape)
-  padding = []
   for dim,(dim_size, idx) in enumerate(zip(self.shape, indices)):
     print(f"dim={dim}, idx={idx}, dim_size={dim_size}")
     if isinstance(idx, int):

--- a/test/test_setitem.py
+++ b/test/test_setitem.py
@@ -188,10 +188,13 @@ class TestSetitem(unittest.TestCase):
     t[-2:-5] = Tensor.ones(0, 3, 3)
     np.testing.assert_allclose(t.numpy(), np.zeros((3,3,3)))
 
-  def test_setitem_slice_broadcast_minimal():
+  def test_setitem_slice_broadcast_minimal(self):
     t = Tensor.zeros(6, 5, 4).contiguous()
     v = Tensor.ones(6, 4)  # Missing middle dimension
     t[:, 1, :] = v
+    n = np.zeros((6, 5, 4))
+    n[:, 1, :] = 1
+    np.testing.assert_allclose(t.numpy(), n)
 
 class TestWithGrad(unittest.TestCase):
   def test_no_requires_grad_works(self):

--- a/test/test_setitem.py
+++ b/test/test_setitem.py
@@ -179,14 +179,14 @@ class TestSetitem(unittest.TestCase):
     self.assertEqual(t.tolist(), [val]*idx_size+[idx_size])
 
   def test_setitem_broadcast_fewer_dims(self):
-      t = Tensor.zeros(2, 3).contiguous()
-      t[:, 1] = Tensor.ones(2)
-      np.testing.assert_allclose(t.numpy(), np.array([[0, 1, 0],[0, 1, 0]]))
+    t = Tensor.zeros(2, 3).contiguous()
+    t[:, 1] = Tensor.ones(2)
+    np.testing.assert_allclose(t.numpy(), np.array([[0, 1, 0],[0, 1, 0]]))
 
   def test_setitem_empty(self):
-      t = Tensor.zeros(3, 3, 3).contiguous()
-      t[-2:-5] = Tensor.ones(0, 3, 3)
-      np.testing.assert_allclose(t.numpy(), np.zeros((3,3,3)))
+    t = Tensor.zeros(3, 3, 3).contiguous()
+    t[-2:-5] = Tensor.ones(0, 3, 3)
+    np.testing.assert_allclose(t.numpy(), np.zeros((3,3,3)))
 
 class TestWithGrad(unittest.TestCase):
   def test_no_requires_grad_works(self):

--- a/test/test_setitem.py
+++ b/test/test_setitem.py
@@ -121,6 +121,7 @@ class TestSetitem(unittest.TestCase):
     @TinyJit
     def f(t:Tensor, a:Tensor):
       t[2:4, 3:5] = a
+      t.realize()
 
     for i in range(1, 6):
       t = Tensor.zeros(6, 6).contiguous().realize()

--- a/test/test_setitem.py
+++ b/test/test_setitem.py
@@ -188,6 +188,11 @@ class TestSetitem(unittest.TestCase):
     t[-2:-5] = Tensor.ones(0, 3, 3)
     np.testing.assert_allclose(t.numpy(), np.zeros((3,3,3)))
 
+  def test_setitem_slice_broadcast_minimal():
+    t = Tensor.zeros(6, 5, 4).contiguous()
+    v = Tensor.ones(6, 4)  # Missing middle dimension
+    t[:, 1, :] = v
+
 class TestWithGrad(unittest.TestCase):
   def test_no_requires_grad_works(self):
     z = Tensor.rand(8, 8)

--- a/test/test_setitem.py
+++ b/test/test_setitem.py
@@ -183,6 +183,11 @@ class TestSetitem(unittest.TestCase):
       t[:, 1] = Tensor.ones(2)
       np.testing.assert_allclose(t.numpy(), np.array([[0, 1, 0],[0, 1, 0]]))
 
+  def test_setitem_empty(self):
+      t = Tensor.zeros(3, 3, 3).contiguous()
+      t[-2:-5] = Tensor.ones(0, 3, 3)
+      np.testing.assert_allclose(t.numpy(), np.zeros((3,3,3)))
+
 class TestWithGrad(unittest.TestCase):
   def test_no_requires_grad_works(self):
     z = Tensor.rand(8, 8)

--- a/test/test_setitem.py
+++ b/test/test_setitem.py
@@ -135,7 +135,6 @@ class TestSetitem(unittest.TestCase):
     @TinyJit
     def f(t:Tensor, a:Tensor):
       t[2:4, 3:5] = a
-      t.realize()
 
     for i in range(1, 6):
       t = Tensor.zeros(6, 6).contiguous().realize()

--- a/test/test_setitem.py
+++ b/test/test_setitem.py
@@ -179,10 +179,9 @@ class TestSetitem(unittest.TestCase):
     self.assertEqual(t.tolist(), [val]*idx_size+[idx_size])
 
   def test_setitem_broadcast_fewer_dims(self):
-      target = Tensor.zeros(2, 3).contiguous()
-      value = Tensor.ones(2)
-      target[:, 1] = value    # Should broadcast (2,) to (2, 1)
-      np.testing.assert_allclose(target.numpy(), np.array([[0, 1, 0],[0, 1, 0]]))
+      t = Tensor.zeros(2, 3).contiguous()
+      t[:, 1] = Tensor.ones(2)
+      np.testing.assert_allclose(t.numpy(), np.array([[0, 1, 0],[0, 1, 0]]))
 
 class TestWithGrad(unittest.TestCase):
   def test_no_requires_grad_works(self):

--- a/test/test_setitem.py
+++ b/test/test_setitem.py
@@ -178,6 +178,12 @@ class TestSetitem(unittest.TestCase):
     t[idx] = val
     self.assertEqual(t.tolist(), [val]*idx_size+[idx_size])
 
+  def test_setitem_broadcast_fewer_dims(self):
+      target = Tensor.zeros(2, 3).contiguous()
+      value = Tensor.ones(2)
+      target[:, 1] = value    # Should broadcast (2,) to (2, 1)
+      np.testing.assert_allclose(target.numpy(), np.array([[0, 1, 0],[0, 1, 0]]))
+
 class TestWithGrad(unittest.TestCase):
   def test_no_requires_grad_works(self):
     z = Tensor.rand(8, 8)

--- a/test/test_setitem.py
+++ b/test/test_setitem.py
@@ -36,6 +36,18 @@ class TestSetitem(unittest.TestCase):
     t[:3] *= 10
     self.assertListEqual(t.tolist(), [0, 10, 20, 3, 4, 5, 6, 7, 8, 9])
 
+  def test_setitem_inplace_mul_ok(self):
+    t = Tensor.arange(10).realize()
+    t[:3] = t[:3] * 10
+    self.assertListEqual(t.tolist(), [0, 10, 20, 3, 4, 5, 6, 7, 8, 9])
+
+  def test_setitem_inplace_mul_internal(self):
+    t = Tensor.arange(10).realize()
+    s = t[:3]
+    s *= 10
+    t[:3] = s
+    self.assertListEqual(t.tolist(), [0, 10, 20, 3, 4, 5, 6, 7, 8, 9])
+
   def test_setitem_into_unrealized(self):
     t = Tensor.arange(4).reshape(2, 2)
     t[1] = 5

--- a/test/test_setitem.py
+++ b/test/test_setitem.py
@@ -14,6 +14,8 @@ class TestSetitem(unittest.TestCase):
       ((4,4,4,4), (Ellipsis, slice(1,3), slice(None)), Tensor(4)),
       ((4,4,4,4), (Ellipsis, slice(1,3)), 4),
       ((4,4,4,4), (2, slice(1,3), None, 1), 4),
+      ((4,4,4,4), (2, slice(1,3), None, 1, slice(0, 4, 1)), 4),
+      ((4,4,4,4), (2, slice(1,3), None, 1, slice(3, None, -1)), 4),
       ((4,4,4,4), (slice(1,3), slice(None), slice(0,4,2)), 4),
       ((4,4,4,4), (slice(1,3), slice(None), slice(None), slice(0,3)), 4),
       ((6,6), (slice(1,5,2), slice(0,5,3)), 1.0),
@@ -190,11 +192,18 @@ class TestSetitem(unittest.TestCase):
 
   def test_setitem_slice_broadcast_minimal(self):
     t = Tensor.zeros(6, 5, 4).contiguous()
-    v = Tensor.ones(6, 4)  # Missing middle dimension
-    t[:, 1, :] = v
+    t[:, 1, :] = Tensor.ones(6, 4)
     n = np.zeros((6, 5, 4))
-    n[:, 1, :] = 1
+    n[:, 1, :] = np.ones((6, 4))
     np.testing.assert_allclose(t.numpy(), n)
+
+  def test_setitem_none(self):
+    t = Tensor.zeros(3, 3).contiguous()
+    t[1:2, None, -1] = Tensor.ones(1, 1)
+    n = np.zeros((3, 3))
+    n[1:2, None, -1] = np.ones((1, 1))
+    np.testing.assert_allclose(t.numpy(), n)
+
 
 class TestWithGrad(unittest.TestCase):
   def test_no_requires_grad_works(self):

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -1127,11 +1127,10 @@ class Tensor(MathTrait):
     return X.shrink(tuple((-min(pB,0), min(pA+s,s)) for (pB,pA),s in zip(pX, X.shape)))
 
   # ***** movement high level ops *****
-
-  def _getitem(self, indices, v: Tensor|None = None) -> Tensor:
+  def _parse_indices(self, indices) -> list[dict[str, sint|Tensor|UOp|None]]:
     # wrap single index into a list
     if (isinstance(indices, list) and all_int(indices)) or not isinstance(indices, (tuple, list)): indices = [indices]
-    x, indices = self, list(indices)
+    indices = list(indices)
 
     # fill ellipsis or rest of indices with slice(None)
     if len(ellipsis_idx := [dim for dim, i in enumerate(indices) if i is Ellipsis]) > 1: raise IndexError("indices can only have a single ellipsis")
@@ -1176,6 +1175,11 @@ class Tensor(MathTrait):
         case _: raise IndexError(f"{type(index).__name__} indexing is not supported")
       indices_parsed.append({"index":index, "size":size, "boundary":tuple(boundary), "stride":stride})
       if index is not None: dim += 1
+    return indices_parsed
+
+  def _getitem(self, indices, v: Tensor|None = None) -> Tensor:
+    x = self
+    indices_parsed = self._parse_indices(indices)
 
     # movement op indexing
     if mops := [i for i in indices_parsed if i['index'] is not None]:

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -1333,11 +1333,7 @@ class Tensor(MathTrait):
       if isinstance(idx, int):
         res_shape.append(1)
       elif isinstance(idx, slice):
-        start = idx.start or 0
-        stop = idx.stop
-        step = idx.step or 1
-        if idx.stop is None:
-          stop = dim_size if step > 0 else -1
+        start, stop, step = idx.indices(dim_size)
         size = (abs(stop - start) + abs(step) - 1) // abs(step)
         res_shape.append(size)
       elif idx is None:
@@ -1356,12 +1352,9 @@ class Tensor(MathTrait):
       if isinstance(idx, int):
         pass
       elif isinstance(idx, slice):
-        start = idx.start or 0
-        stop = idx.stop or dim_size
-        step = idx.step or 1
+        start, stop, step = idx.indices(dim_size)
         if step < 0:
           vb = vb.flip(dim)
-          stop = idx.stop or -1
         if abs(step) > 1:
           # (10,1,30,4,50) -> (10,1,30,12,50) -> (10,1,30,(1+12+17),50)
           vb = vb.repeat_interleave(abs(step), dim=dim)

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -1352,12 +1352,9 @@ class Tensor(MathTrait):
 
   def pad_values(self, v: Tensor, indices):
     vshape = self.gen_index_shape(indices)
-    reduced_vshape = vshape
-    while len(reduced_vshape) > v.ndim and reduced_vshape[-1] == 1: reduced_vshape = reduced_vshape[:-1]
     # e.g.
     # v.shape = (1, 1, 4, 1) -> (10, 1, 30, 4, 50)
-    vb = v._broadcast_to(reduced_vshape)
-    while len(vshape) > vb.ndim: vb = vb.unsqueeze(-1)
+    vb = v.squeeze()._broadcast_to(tuple(sh for sh in vshape if sh != 1)).reshape(vshape)
     dim = 0
     for idx in indices:
       if isinstance(idx, int):

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -1127,10 +1127,11 @@ class Tensor(MathTrait):
     return X.shrink(tuple((-min(pB,0), min(pA+s,s)) for (pB,pA),s in zip(pX, X.shape)))
 
   # ***** movement high level ops *****
-  def _parse_indices(self, indices) -> list[dict[str, sint|Tensor|UOp|None]]:
+
+  def _getitem(self, indices, v: Tensor|None = None) -> Tensor:
     # wrap single index into a list
     if (isinstance(indices, list) and all_int(indices)) or not isinstance(indices, (tuple, list)): indices = [indices]
-    indices = list(indices)
+    x, indices = self, list(indices)
 
     # fill ellipsis or rest of indices with slice(None)
     if len(ellipsis_idx := [dim for dim, i in enumerate(indices) if i is Ellipsis]) > 1: raise IndexError("indices can only have a single ellipsis")
@@ -1175,11 +1176,6 @@ class Tensor(MathTrait):
         case _: raise IndexError(f"{type(index).__name__} indexing is not supported")
       indices_parsed.append({"index":index, "size":size, "boundary":tuple(boundary), "stride":stride})
       if index is not None: dim += 1
-    return indices_parsed
-
-  def _getitem(self, indices, v: Tensor|None = None) -> Tensor:
-    x = self
-    indices_parsed = self._parse_indices(indices)
 
     # movement op indexing
     if mops := [i for i in indices_parsed if i['index'] is not None]:

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -3892,7 +3892,7 @@ class Tensor(MathTrait):
 
   def __iadd__(self, x) -> Tensor: return self.assign(self.add(x))
   def __isub__(self, x) -> Tensor: return self.assign(self.sub(x))
-  def __imul__(self, x) -> Tensor: return self.replace(self.mul(x))
+  def __imul__(self, x) -> Tensor: return self.assign(self.mul(x))
   def __ipow__(self, x) -> Tensor: return self.assign(self.pow(x))
   def __itruediv__(self, x) -> Tensor: return self.assign(self.div(x))
   def __ifloordiv__(self, x) -> Tensor: return self.assign(self.__floordiv__(x))

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -1326,7 +1326,6 @@ class Tensor(MathTrait):
   x[:, 3, ..., 1:12:3] = v
   """
   def gen_index_shape(self, indices):
-    masks = []
     indices = list(indices) + [None]*(self.ndim - len(indices))
     res_shape = []
     for (dim_size, idx) in zip(self.shape, indices):
@@ -1347,7 +1346,6 @@ class Tensor(MathTrait):
     # e.g.
     # v.shape = (1, 1, 4, 1) -> (10, 1, 30, 4, 50)
     vb = v._broadcast_to(vshape)
-    padding = []
     for dim,(dim_size, idx) in enumerate(zip(self.shape, indices)):
       if isinstance(idx, int):
         pass
@@ -1378,7 +1376,6 @@ class Tensor(MathTrait):
     mask = self.gen_mask(indices)
     vb = self.pad_values(v, indices)
     return mask.where(vb, self)
-
 
   def gather(self:Tensor, dim:int, index:Tensor) -> Tensor:
     """

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -3889,7 +3889,7 @@ class Tensor(MathTrait):
 
   def __iadd__(self, x) -> Tensor: return self.assign(self.add(x))
   def __isub__(self, x) -> Tensor: return self.assign(self.sub(x))
-  def __imul__(self, x) -> Tensor: return self.assign(self.mul(x))
+  def __imul__(self, x) -> Tensor: return self.replace(self.mul(x))
   def __ipow__(self, x) -> Tensor: return self.assign(self.pow(x))
   def __itruediv__(self, x) -> Tensor: return self.assign(self.div(x))
   def __ifloordiv__(self, x) -> Tensor: return self.assign(self.__floordiv__(x))

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -1374,7 +1374,7 @@ class Tensor(MathTrait):
           right_pad = dim_size - start - 1
           left_pad = dim_size - vb.shape[dim] - right_pad
           pad = (left_pad, right_pad)
-        pads = (None,) * dim + (pad, ) + (None,) * (self.ndim - dim - 1)
+        pads = (None,) * dim + (pad, ) + (None,) * (vb.ndim - dim - 1)
         vb = vb.pad(pads)
       elif idx is None:
         vb = vb.squeeze(dim)

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -1358,9 +1358,7 @@ class Tensor(MathTrait):
     dim = 0
     for idx in indices:
       if isinstance(idx, int):
-        dim_size = self.shape[dim]
-        if dim_size > 0:
-          vb = vb.repeat_interleave(dim_size, dim=dim)
+        pass
       elif isinstance(idx, slice):
         dim_size = self.shape[dim]
         start, _, step = idx.indices(cast(SupportsIndex, dim_size))

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -1340,7 +1340,8 @@ class Tensor(MathTrait):
       elif isinstance(idx, slice):
         dim_size = self.shape[dim]
         start, stop, step = idx.indices(cast(SupportsIndex, dim_size))
-        size = (abs(stop - start) + abs(step) - 1) // abs(step)
+        if (stop - start) * step < 0: size = 0
+        else: size = (abs(stop - start) + abs(step) - 1) // abs(step)
         res_shape.append(size)
       elif idx is None:
         res_shape.append(1)

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -1356,7 +1356,7 @@ class Tensor(MathTrait):
       if isinstance(idx, int):
         pass
       elif isinstance(idx, slice):
-        start, stop, step = idx.indices(dim_size)
+        start, _, step = idx.indices(dim_size)
         if step < 0:
           vb = vb.flip(dim)
         if abs(step) > 1:

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -1354,10 +1354,12 @@ class Tensor(MathTrait):
     # e.g.
     # v.shape = (1, 1, 4, 1) -> (10, 1, 30, 4, 50)
     vb = v._broadcast_to(vshape)
-    for dim,(dim_size, idx) in enumerate(zip(self.shape, indices)):
+    dim = 0
+    for idx in indices:
       if isinstance(idx, int):
         pass
       elif isinstance(idx, slice):
+        dim_size = self.shape[dim]
         start, _, step = idx.indices(cast(SupportsIndex, dim_size))
         if step < 0:
           vb = vb.flip(dim)
@@ -1375,9 +1377,10 @@ class Tensor(MathTrait):
         pads = (None,) * dim + (pad, ) + (None,) * (self.ndim - dim - 1)
         vb = vb.pad(pads)
       elif idx is None:
-        pass
+        vb = vb.squeeze(dim)
       else:
         raise NotImplementedError(f"Indexing with {type(idx)} not supported")
+      if idx is not None: dim += 1
     return vb
 
   def setitem(self: Tensor, indices, v: Tensor):

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -1351,9 +1351,12 @@ class Tensor(MathTrait):
 
   def pad_values(self, v: Tensor, indices):
     vshape = self.gen_index_shape(indices)
+    reduced_vshape = vshape
+    while len(reduced_vshape) > v.ndim and reduced_vshape[-1] == 1: reduced_vshape = reduced_vshape[:-1]
     # e.g.
     # v.shape = (1, 1, 4, 1) -> (10, 1, 30, 4, 50)
-    vb = v._broadcast_to(vshape)
+    vb = v._broadcast_to(reduced_vshape)
+    while len(vshape) > vb.ndim: vb = vb.unsqueeze(-1)
     dim = 0
     for idx in indices:
       if isinstance(idx, int):

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -1314,7 +1314,8 @@ class Tensor(MathTrait):
         # Negative start/stop is handled by slice.indices, but negative step could be tricky
         dim_size = self.shape[dim]
         start, stop, step = idx.indices(cast(SupportsIndex, dim_size))
-        mask = Tensor.arange(start, stop, step).unsqueeze(-1)._one_hot_along_dim(dim_size).sum(0).reshape((1,)*dim + (dim_size,) + (1,)*(self.ndim-dim-1)).expand(self.shape)
+        mask = Tensor.arange(start, stop, step).unsqueeze(-1)._one_hot_along_dim(dim_size).sum(0)
+        mask = mask.reshape((1,)*dim + (dim_size,) + (1,)*(self.ndim-dim-1)).expand(self.shape)
       elif idx is None:
         continue
       else:


### PR DESCRIPTION
Below is a draft PR message for future PR to `tinygrad/tinygrad` repository.

---
[Bounty] Remove realize from __setitem__ and get TestSetitemLoop.test_arange to be one kernel
---

## Overview

This PR optimizes setitem operations by removing the `realize()` call from the `__setitem__` method in the Tensor class. 

- [x] integer indexing
- [x] slice indexing
- [x] ellipsis indexing
- [x] None indexing
- [ ] Tensor indexing (not supported yet, but properly handled by existing code `_getitem`)

The pseudo code for the new `__setitem__` implementation is as follows:

```python
def __setitem__(self, indices, v):
  mask = self._generate_setitem_mask(indices)
  padded_v - self._generate_setitem_padded_value(indices, v)
  res = mask.where(padded_v, self)
  self.assign(res)
```

## Performance Improvement

**TestSetitemLoop.test_arange benchmark** with `RANGEIFY=1`:
- **Master branch**: 20 kernels scheduled in total
- **This PR**: 3 kernels  
- **Command**: `DEBUG=1 RANGEIFY=1 python -m pytest test/test_setitem.py::TestSetitemLoop -rP`
- **Improvement**: 85% reduction in kernel count

This optimization significantly benefits scenarios with repeated setitem operations, such as tensor initialization loops and in-place tensor modifications.

## ❌ Failing Test Case

### 1. `test_setitem.py::TestSetitem::test_setitem_inplace_mul`  
**Error**: `AssertionError: must be BUFFER Ops.BUFFER_VIEW`

**Root cause**: The `assign` method cannot properly handle tensor views (even contiguous slices) during buffer realization. When inplace operations like `*=` call `assign` on slice views, the underlying buffer system fails because it encounters a `BUFFER_VIEW` operation instead of the expected `BUFFER` operation.

**Technical details**:
```
t[:3] = t[:3] * 10 # This works fine
t[:3] *= 10        # But this causes a crash when realized
```
- Python interpreter internally translates the expression like this `t[:3] *= 10` into the code below:
```python
_slice = t[:3]
_slice += 10
t[:3] = _slice
```
- During realization, the buffer property assertion fails: `assert self.op is Ops.BUFFER`  
- The system encounters `Ops.BUFFER_VIEW` instead of `Ops.BUFFER`, causing the crash

**Conflict**: This test can be fixed by changing `__imul__` to use `replace` instead of `assign`, but then `test_assign.py::TestAssign::test_permuted_assignment` would fail because it expects inplace operations to properly reject non-contiguous tensors.

### 2. `test/test_setitem.py::TestSetitem::test_simple_jit_setitem`
**Error**: `AssertionError: didn't JIT anything!`
**Rot cause**: Since I removed realize() call from `__setitem__`, the function `f` does no longer JIT compiled. Maybe we can call additional `t.realize()` inside f or should we simply remove this test?

```
  def test_simple_jit_setitem(self):
    @TinyJit
    def f(t:Tensor, a:Tensor):
      t[2:4, 3:5] = a

    for i in range(1, 6):
      t = Tensor.zeros(6, 6).contiguous().realize()
      a = Tensor.full((2, 2), fill_value=i, dtype=dtypes.float).contiguous()
      f(t, a)

      n = np.zeros((6, 6))
      n[2:4, 3:5] = np.full((2, 2), i)
      np.testing.assert_allclose(t.numpy(), n)
```

## Possible Solutions

I'm considering these approaches, but unsure which is best. Are there better alternatives?

1. **Fix assign for views**: Modify `assign` method to detect slice views and handle them appropriately  
2. **Fix buffer realization**: Update the `realize()` pipeline to properly handle `BUFFER_VIEW` operations
